### PR TITLE
feat: update base uri and trusted origin urls

### DIFF
--- a/apis_ontology/settings/settings.py
+++ b/apis_ontology/settings/settings.py
@@ -3,15 +3,15 @@ from pathlib import Path
 
 BASE_DIR = Path(__file__).resolve().parent
 DEBUG = True
-APIS_BASE_URI = "https://hgm.acdh-dev.oeaw.ac.at/"
+APIS_BASE_URI = "https://hmg.acdh-dev.oeaw.ac.at/"
 ROOT_URLCONF = "apis_ontology.urls"
 
 MIDDLEWARE += [
     "simple_history.middleware.HistoryRequestMiddleware",
 ]
 CSRF_TRUSTED_ORIGINS = [
-    "https://hgm.acdh.oeaw.ac.at",
-    "https://hgm.acdh-dev.oeaw.ac.at",
+    "https://hmg.acdh.oeaw.ac.at",
+    "https://hmg.acdh-dev.oeaw.ac.at",
 ]
 if DEBUG:
     INTERNAL_IPS = [


### PR DESCRIPTION
This pull request includes a small but important update to the `apis_ontology/settings/settings.py` file. The changes correct a typo in the base URI and trusted origins to ensure consistency and proper functionality.

* [`apis_ontology/settings/settings.py`](diffhunk://#diff-19f68ce3c9152c44923d4b48068c285580ec23bca72c13d5d823b0241b0fa011L6-R14): Updated `APIS_BASE_URI` and `CSRF_TRUSTED_ORIGINS` to replace "hgm" with "hmg" in the URLs.