### PR TITLE
feat: include place categories in voacabulary

### DIFF
--- a/apis_ontology/management/commands/01_populate_vocabulary.py
+++ b/apis_ontology/management/commands/01_populate_vocabulary.py
@@ -4,7 +4,7 @@ Initializes the vocabulary for the data model
 
 from django.core.management.base import BaseCommand
 
-from apis_ontology.models import EventCategory, Title
+from apis_ontology.models import EventCategory, Title, PlaceCategory
 
 EVENT_CATEGORIES = [
     "Assistenzeinsatz",
@@ -70,6 +70,21 @@ TITLES = {
     ],
 }
 
+PLACE_TYPES = [
+    "Stadt",
+    "Bundesland",
+    "Bezirk",
+    "Kanton",
+    "Provinz",
+    "Staat",
+    "Kaserne",
+    "Flugplatz",
+    "Kommandogebäude",
+    "Gedenkstätte",
+    "Erinnerungsort",
+    "Gemeinde",
+]
+
 
 class Command(BaseCommand):
     """Populate the vocabulary with initial data"""
@@ -87,5 +102,8 @@ class Command(BaseCommand):
                 Title.objects.get_or_create(
                     label_type=title_group, abbreviation=t[0], label=t[1]
                 )
+
+        for place_type in sorted(PLACE_TYPES):
+            PlaceCategory.objects.get_or_create(label=place_type)
 
         self.stdout.write(self.style.SUCCESS("Vocabulary populated successfully."))


### PR DESCRIPTION
This pull request updates the `01_populate_vocabulary.py` management command to include support for populating `PlaceCategory` data in addition to existing vocabulary data. The most important changes are focused on adding a new category and ensuring its data is populated during the command execution.

### Additions to vocabulary population:

* [`apis_ontology/management/commands/01_populate_vocabulary.py`](diffhunk://#diff-46598006c6d11509483a6e3aa9fad0defa44cf40db3e7bb1e0cdf7e63e2d990aL7-R7): Added `PlaceCategory` to the imported models to support the new category.
* [`apis_ontology/management/commands/01_populate_vocabulary.py`](diffhunk://#diff-46598006c6d11509483a6e3aa9fad0defa44cf40db3e7bb1e0cdf7e63e2d990aR73-R87): Introduced a `PLACE_TYPES` list containing predefined place types such as "Stadt", "Bundesland", and "Gedenkstätte".
* [`apis_ontology/management/commands/01_populate_vocabulary.py`](diffhunk://#diff-46598006c6d11509483a6e3aa9fad0defa44cf40db3e7bb1e0cdf7e63e2d990aR106-R108): Updated the `handle` method to iterate over `PLACE_TYPES` and create `PlaceCategory` entries in the database.