### PR TITLE
Preserve linebreaks

### DIFF
--- a/apis_ontology/static/styles/hmg.css
+++ b/apis_ontology/static/styles/hmg.css
@@ -1,0 +1,9 @@
+
+body {
+      text-rendering: geometricPrecision;
+}
+
+td.preserve-linebreaks {
+        white-space: pre-wrap;
+    line-break: anywhere;
+}

--- a/apis_ontology/tables.py
+++ b/apis_ontology/tables.py
@@ -19,3 +19,27 @@ class EntityMixinRelationsTable(GenericTable):
             "edit",
             "delete",
         )
+
+
+class GenericListViewTable(GenericTable):
+    class Meta(GenericTable.Meta):
+        attrs = {
+            "td": {"class": "preserve-linebreaks"},
+        }
+        exclude = ["noduplicate"]
+        sequence = (
+            "id",
+            "desc",
+            "...",
+            "view",
+            "edit",
+            "delete",
+        )
+
+
+class EntityMixinTable(GenericListViewTable):
+    pass
+
+
+class RelationMixinTable(GenericListViewTable):
+    pass

--- a/apis_ontology/templates/base.html
+++ b/apis_ontology/templates/base.html
@@ -1,13 +1,14 @@
 {% extends "base.html" %}
 {% load i18n %}
 {% load core %}
+{% load static %}
 
 {% block title %}
-{% if object %}
-{{ object }}
-{% else %}
-He(e)r mit Geschichte
-{% endif %}
+    {% if object %}
+        {{ object }}
+    {% else %}
+        He(e)r mit Geschichte
+    {% endif %}
 {% endblock title %}
 {% block favicons %}
     <link rel="apple-touch-icon"
@@ -25,6 +26,11 @@ He(e)r mit Geschichte
           href="{% shared_url %}favicon/safari-pinned-tab.svg"
           color="#00aba9" />
 {% endblock favicons %}
+{% block styles %}
+    <link href="{% static 'styles/hmg.css' %}" rel="stylesheet" />
+    {{ block.super }}
+{% endblock styles %}
+
 {% block main-menu %}
     <li class="nav-item">
         <a class="navbar-brand d-flex align-items-center mx-0 py-2" href="/">

--- a/apis_ontology/templates/generic/partials/default_model_field_value.html
+++ b/apis_ontology/templates/generic/partials/default_model_field_value.html
@@ -1,0 +1,1 @@
+{% if value %}{{ value|linebreaksbr }}{% endif %}


### PR DESCRIPTION
This pull request introduces improvements to the display and formatting of table data and text in the application. The main focus is on ensuring that line breaks in table cells are preserved and rendered correctly, and on adding a custom stylesheet for enhanced control over appearance. Additionally, new table classes are introduced to support these formatting changes.

**Styling and Rendering Improvements:**

* Added a new stylesheet `hmg.css` with rules to enable geometric precision text rendering for the `body` and to preserve line breaks and allow line wrapping in table cells with the `preserve-linebreaks` class. (`apis_ontology/static/styles/hmg.css`)
* Updated the base template to include the new stylesheet and ensure static files are loaded. (`apis_ontology/templates/base.html`) [[1]](diffhunk://#diff-2d876f80b43737269e59ecad6f487d5c40d5cff2bed8b9645401bc561bb2785aR4) [[2]](diffhunk://#diff-2d876f80b43737269e59ecad6f487d5c40d5cff2bed8b9645401bc561bb2785aR29-R33)
* Modified the default model field value partial to render values with preserved line breaks using the `linebreaksbr` filter. (`apis_ontology/templates/generic/partials/default_model_field_value.html`)

**Table Class Enhancements:**

* Added new table classes (`GenericListViewTable`, `EntityMixinTable`, `RelationMixinTable`) that apply the `preserve-linebreaks` class to table cells, exclude the `noduplicate` field, and define a specific column sequence for list views. (`apis_ontology/tables.py`)