### PR TITLE
feat(entities): use label field as str representation when available

### DIFF
--- a/apis_ontology/models.py
+++ b/apis_ontology/models.py
@@ -103,6 +103,9 @@ class Event(EntityMixin, AbstractEntity, DateMixin, VersionMixin):
         verbose_name_plural = _("Events")
         ordering = ["start"]
 
+    def __str__(self):
+        return f"{self.label} ({self.pk})"
+
 
 class Insigne(EntityMixin, AbstractEntity, GenericModel, VersionMixin):
     """
@@ -115,6 +118,9 @@ class Insigne(EntityMixin, AbstractEntity, GenericModel, VersionMixin):
     class Meta:
         verbose_name = _("Insigne")
         verbose_name_plural = _("Insigia")
+
+    def __str__(self):
+        return f"{self.label} ({self.pk})"
 
 
 class PlaceCategory(GenericModel, SimpleLabelModel):
@@ -197,12 +203,11 @@ class Person(EntityMixin, E21_Person, AbstractEntity, GenericModel, VersionMixin
         Title, blank=True, max_length=255, verbose_name=_("Title")
     )
     honours = models.ManyToManyField(blank=True, to=Honours, verbose_name=_("Honours"))
-    bionote = models.TextField(
-        blank=True, null=True, verbose_name=_("bionote")
-    )
+    bionote = models.TextField(blank=True, null=True, verbose_name=_("bionote"))
     attended_military_basic_education = models.BooleanField(
         default=False, verbose_name=_("Attended military basic education")
     )
+
 
 class Bureau(EntityMixin, E74_Group, AbstractEntity, GenericModel, VersionMixin):
     """


### PR DESCRIPTION
This pull request introduces minor improvements to the `apis_ontology/models.py` file, focusing on enhancing model string representations and code consistency. The most important changes are:

Model string representation enhancements:
* Added a `__str__` method to both the `Event` and `Insigne` models to return a string with the object's label and primary key, improving readability in the Django admin and shell. [[1]](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1R106-R108) [[2]](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1R122-R124)