### PR TITLE
feat(tables): link only subject/object in relations table

### DIFF
--- a/apis_ontology/static/styles/hmg.css
+++ b/apis_ontology/static/styles/hmg.css
@@ -4,6 +4,6 @@ body {
 }
 
 td.preserve-linebreaks {
-        white-space: pre-wrap;
+    white-space: pre-wrap;
     line-break: anywhere;
 }

--- a/apis_ontology/tables.py
+++ b/apis_ontology/tables.py
@@ -1,17 +1,17 @@
 from apis_core.generic.tables import GenericTable
+from apis_core.relations.tables import RelationsListTable
 
 import django_tables2 as tables
 
 
-class EntityMixinRelationsTable(GenericTable):
+class EntityMixinRelationsTable(RelationsListTable):
     start = tables.Column(accessor="start")
     end = tables.Column(accessor="end")
-    # glossary = tables.Column(accessor="glossar_terms")
     notes = tables.Column(accessor="notes")
 
     class Meta(GenericTable.Meta):
         per_page = 1000
-        sequence = ("desc", "...", "actions")
+        sequence = ("relation", "...", "actions")
 
 
 class GenericListViewTable(GenericTable):


### PR DESCRIPTION
This pull request updates the `EntityMixinRelationsTable` class in `apis_ontology/tables.py` to inherit from `RelationsListTable` instead of `GenericTable`, aligning it with the structure provided by the `apis_core.relations` module. Additionally, it updates the column sequence to reflect this change.

Table inheritance and configuration updates:

* Changed `EntityMixinRelationsTable` to inherit from `RelationsListTable` instead of `GenericTable`, which likely provides more specialized behavior for relations tables.
* Updated the `Meta.sequence` attribute from `("desc", "...", "actions")` to `("relation", "...", "actions")` to match the new table structure and column naming.